### PR TITLE
Fixed bug when counting distinct records with db2

### DIFF
--- a/CIbmDB2CommandBuilder.php
+++ b/CIbmDB2CommandBuilder.php
@@ -46,6 +46,19 @@ class CIbmDB2CommandBuilder extends CDbCommandBuilder {
         }
         return $sql;
     }
+    
+    /**
+	 * Creates a COUNT(*) command for a single table.
+	 * @param mixed $table the table schema ({@link CDbTableSchema}) or the table name (string).
+	 * @param CDbCriteria $criteria the query criteria
+	 * @param string $alias the alias name of the primary table. Defaults to 't'.
+	 * @return CDbCommand query command.
+	 */
+    public function createCountCommand($table,$criteria,$alias='t') {
+		$table_clone = clone $table;
+		$table_clone->primaryKey = $this->getSchema()->quoteColumnName($table->primaryKey);
+		return parent::createCountCommand($table_clone,$criteria,$alias);
+	}
 
     /**
      * Creates an UPDATE command.


### PR DESCRIPTION
The Yii internal CDbCommandBuilder does not quote the primary key field before inserting it into the SQL. Therefore, the resulting query was like:
SELECT COUNT(DISTINCT "table".id) ...

But it should be:
SELECT COUNT(DISTINCT "table"."id") ...
